### PR TITLE
Add aarch64 archtecture same as arm64 in Linux

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -20,7 +20,7 @@ case "$(uname -s)" in
     ;;
   "Linux")
     case "$(uname -m)" in
-      "arm64")
+      "arm64" | "aarch64")
         DOWNLOAD_URL="https://github.com/soracom/soracom-cli/releases/download/v${ASDF_INSTALL_VERSION}/soracom_${ASDF_INSTALL_VERSION}_linux_arm64.tar.gz"
 				curl -fL -o "${ASDF_DOWNLOAD_PATH}/soracom.tar.gz" "${DOWNLOAD_URL}"
         ;;

--- a/bin/install
+++ b/bin/install
@@ -25,7 +25,7 @@ case "$(uname -s)" in
     ;;
   "Linux")
     case "$(uname -m)" in
-      "arm64")
+      "arm64" | "aarch64")
 			  tar xzf soracom.tar.gz
 				mv ./soracom_${ASDF_INSTALL_VERSION}_linux_arm64/soracom "${toolPath}"
         ;;


### PR DESCRIPTION
## Summary

Any SBCs(Single Board Computes)  using Arm64 return `aarch64` by `uname -m`. (e.g. Raspberry Pi with bookworm). Supported to it.

## Notes

* No need to impliment it specially, just use it as if it is `arm64`.
* Darwin does not return `aarch64`.

EoT